### PR TITLE
feat: refresh frontend style

### DIFF
--- a/frontend/static/style.css
+++ b/frontend/static/style.css
@@ -1,8 +1,8 @@
 :root {
-  --primary-color: #FFFF00;
-  --primary-dark: #E6E600;
-  --text-color: #333;
-  --background-color: #FFFFF0;
+  --primary-color: #FFF967;
+  --primary-dark: #E6E056;
+  --text-color: #000000;
+  --background-color: #FFFCE8;
   --card-background: #FFFFFF;
   --shadow-color: rgba(0, 0, 0, 0.1);
 }
@@ -19,12 +19,6 @@ body {
   color: var(--text-color);
   line-height: 1.6;
   min-height: 100vh;
-}
-
-.box-btn.selected {
-    background: #2d2dff;
-    color: #fff;
-    border-color: #2d2dff;
 }
 
 .box-btn[disabled] {
@@ -62,6 +56,17 @@ body {
     margin: 1rem;
     padding: 1rem;
   }
+}
+
+/* Consistent card width across sections */
+.header,
+.box-btns,
+.scrollable-text,
+.page-nav {
+  width: 100%;
+  max-width: 900px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .header {
@@ -171,7 +176,7 @@ body:not([data-page="0"]) .header {
 }
 
 .niche-input::placeholder {
-  color: rgba(51, 51, 51, 0.6);
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .niche-input:focus {
@@ -268,6 +273,7 @@ body:not([data-page="0"]) .box-btns {
 
 .box-btn.selected {
   background: var(--primary-color);
+  color: var(--text-color);
   transform: translateY(-4px);
   box-shadow: 0 8px 24px var(--shadow-color);
 }
@@ -335,8 +341,8 @@ body:not([data-page="0"]) .sources-btn {
     display: inline-block;
 }
 .sources-btn:active {
-    background: #2d2dff;
-    color: #fff;
+    background: var(--text-color);
+    color: var(--primary-color);
 }
 
 .page-nav {

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -5,10 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ScriptWriter</title>
     <meta name="description" content="ScriptWriter - AI-powered content creation tool">
-    <meta name="theme-color" content="#FFFF00">
+    <meta name="theme-color" content="#FFF967">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:wght@300..800&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', path='style.css') }}">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- adopt Bricolage Grotesque font and update theme color
- unify card layout widths and palette for a cleaner look

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897faf6e05c8333ae48259b0fd35199